### PR TITLE
Search for any `lib/pkgconfig/*.pc` or `share/pkgconfig/*.pc` file.

### DIFF
--- a/colcon_pkg_config/environment/pkg_config.py
+++ b/colcon_pkg_config/environment/pkg_config.py
@@ -24,13 +24,15 @@ class PkgConfigEnvironment(EnvironmentExtensionPoint):
 
     def create_environment_hooks(self, prefix_path, pkg_name):  # noqa: D102
         environment_hooks = []
-        subdirectories = [Path('lib') / 'pkgconfig',
-                          Path('share') / 'pkgconfig']
+        subdirectories = [Path('share') / 'pkgconfig'] \
+            + [(p / 'pkgconfig').relative_to(prefix_path)
+               for p in prefix_path.glob('lib*')]
         for subdirectory in subdirectories:
             full_pkgconfig_path = prefix_path / subdirectory
             logger.log(1, "checking '%s' for .pc files" % full_pkgconfig_path)
             if any(full_pkgconfig_path.glob('*.pc')):
                 environment_hooks += create_environment_hook(
-                    'pkg_config', prefix_path, pkg_name, 'PKG_CONFIG_PATH',
+                    'pkg_config_%s' % subdirectory.parent.name,
+                    prefix_path, pkg_name, 'PKG_CONFIG_PATH',
                     str(subdirectory), mode='prepend')
         return environment_hooks

--- a/colcon_pkg_config/environment/pkg_config.py
+++ b/colcon_pkg_config/environment/pkg_config.py
@@ -13,8 +13,8 @@ class PkgConfigEnvironment(EnvironmentExtensionPoint):
     """
     Extend the environment variable PKG_CONFIG_PATH.
 
-    A package needs to provide the file 'lib/pkgconfig/<pkgname>.pc' to extend
-    the environment variable.
+    A package needs to provide files 'lib/pkgconfig/*.pc' or
+    'share/pkgconfig/*.pc' to extend the environment variable.
     """
 
     def __init__(self):  # noqa: D107
@@ -23,11 +23,14 @@ class PkgConfigEnvironment(EnvironmentExtensionPoint):
             EnvironmentExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
 
     def create_environment_hooks(self, prefix_path, pkg_name):  # noqa: D102
-        subdirectory = Path('lib') / 'pkgconfig'
-        pkg_config_file = prefix_path / subdirectory / (pkg_name + '.pc')
-        logger.log(1, "checking '%s'" % pkg_config_file)
-        if not pkg_config_file.is_file():
-            return []
-        return create_environment_hook(
-            'pkg_config', prefix_path, pkg_name, 'PKG_CONFIG_PATH',
-            str(subdirectory), mode='prepend')
+        environment_hooks = []
+        subdirectories = [Path('lib') / 'pkgconfig',
+                          Path('share') / 'pkgconfig']
+        for subdirectory in subdirectories:
+            full_pkgconfig_path = prefix_path / subdirectory
+            logger.log(1, "checking '%s' for .pc files" % full_pkgconfig_path)
+            if any(full_pkgconfig_path.glob('*.pc')):
+                environment_hooks += create_environment_hook(
+                    'pkg_config', prefix_path, pkg_name, 'PKG_CONFIG_PATH',
+                    str(subdirectory), mode='prepend')
+        return environment_hooks

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -5,7 +5,6 @@ linter
 noqa
 pathlib
 pkgconfig
-pkgname
 plugin
 prepend
 pydocstyle


### PR DESCRIPTION
This is a change to search for any `lib/pkgconfig/*.pc` or `share/pkgconfig/*.pc` file and create environment hooks accordingly. 

The search within `share` is to resolve issue https://github.com/colcon/colcon-pkg-config/issues/16. 

The search for any "*.pc" file is to allow a package to install multiple "*.pc" files when the package builds multiple modules and is also less strict about the ".pc" file name matching the package name exactly.